### PR TITLE
pc - allow entity references and inline styles

### DIFF
--- a/lint_html.py
+++ b/lint_html.py
@@ -22,7 +22,9 @@ from xml.etree import ElementTree as ET
 #   H030 - meta description (fragments don't need it)
 #   H031 - meta keywords (fragments don't need it)
 #   T001 - mustache variable whitespace style (cosmetic, not an error)
-_DJLINT_IGNORE = "H005,H007,H014,H030,H031,T001"
+#   H023 - this rules checks for entity references (but we allow those in PL HTML)
+#   H021 - this rule checks for inline styles (but we allow those in PL HTML)
+_DJLINT_IGNORE = "H005,H007,H014,H030,H031,T001,H023,H021"
 
 
 def find_html_files(root_dir="."):


### PR DESCRIPTION
This pull request updates the linting configuration in `lint_html.py` to further relax the HTML linting rules for the project. The main change is the addition of two more rule codes to the `_DJLINT_IGNORE` list, allowing for entity references and inline styles in Pattern Library HTML files.

**Linting rule adjustments:**

* Updated `_DJLINT_IGNORE` to also ignore rules `H023` (entity references) and `H021` (inline styles), reflecting the project's acceptance of these patterns in PL HTML.